### PR TITLE
Adding deck.gl as dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@types/react-slider": "^1.3.6",
     "@types/react-window": "^1.8.8",
     "@vitejs/plugin-react": "^4.3.4",
+    "deck.gl": "^9.1.11",
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",


### PR DESCRIPTION
@dzole0311 I followed your `Installation` to the tee and still ran into this error:
![Screenshot 2025-05-08 at 8 35 14 AM](https://github.com/user-attachments/assets/edbf225e-022f-46ce-aa63-d327903f7e48)

so I added `deck.gl` as a dev dependency and it worked. Maybe you had it installed globally or something? Creating this but maybe the instructions should be updated instead? 