### PR TITLE
Adding Canada data to map viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dsio/wildfire-explorer",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/src/components/layers/hooks/useLayers.ts
+++ b/src/components/layers/hooks/useLayers.ts
@@ -54,9 +54,9 @@ export const useLayers = ({
   const { mapboxAccessToken, featuresApiEndpoint: baseUrl } = useEnv();
 
   const MVT_URLS: Record<MVTLayerId, string> = {
-    perimeterNrt: `${baseUrl}/collections/public.eis_fire_lf_perimeter_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-125.0,24.5,-66.0,49.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`,
-    fireline: `${baseUrl}/collections/public.eis_fire_lf_fireline_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-125.0,24.5,-66.0,49.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`,
-    newfirepix: `${baseUrl}/collections/public.eis_fire_lf_newfirepix_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-125.0,24.5,-66.0,49.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`
+    perimeterNrt: `${baseUrl}/collections/public.eis_fire_lf_perimeter_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-165.0,24.5,-66.0,69.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`,
+    fireline: `${baseUrl}/collections/public.eis_fire_lf_fireline_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-165.0,24.5,-66.0,69.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`,
+    newfirepix: `${baseUrl}/collections/public.eis_fire_lf_newfirepix_nrt/tiles/WebMercatorQuad/{z}/{x}/{y}?bbox=-165.0,24.5,-66.0,69.5&properties=duration,farea,meanfrp,fperim,n_pixels,n_newpixels,pixden,fireid,primarykey,t,region`
   };
 
   const [layers, setLayers] = useState([]);


### PR DESCRIPTION
@hanbyul-here  - we received a request to include some of the Canada data in the map viewer. Following some exploration @zebbecker and I did the other day, I updated the bbox query parameters for our FEDS data. Based on Zeb and I's testing, I believe this is all that is needed to make this _functional_. That said, it looks like the MVTLayers [are bounded](https://github.com/eorland/us-fire-events-tool/blob/cb1b7c6b596ebada08eb5b6b22e998fef43e04f1/src/components/layers/MVTLayer.tsx#L30) by a USA-only box. It's not quite clear to me if this also needs to be updated for the data to display, if this helps only helps with faster rendering. Hoping this PR can start the discussion. 

This request to include the Canada data was marked as "asap" from leadership on our end, so I'm doing what I can to get the ball rolling.