### PR TITLE
Feat deck mobile optimizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsio/wildfire-explorer",
-  "version": "0.4.6",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dsio/wildfire-explorer",
-      "version": "0.4.6",
+      "version": "0.6.2",
       "dependencies": {
         "@deck.gl/extensions": "^9.1.4",
         "@deck.gl/react": "^9.1.4",
@@ -29,6 +29,7 @@
         "mapbox-gl": "^3.10.0",
         "react": "^18.2.0",
         "react-calendar": "^5.1.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^18.2.0",
         "react-map-gl": "^8.0.1",
         "react-router-dom": "^7.2.0",
@@ -5502,6 +5503,19 @@
         }
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
@@ -6435,6 +6449,32 @@
     "node_modules/typewise-core": {
       "version": "1.2.0",
       "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mapbox-gl": "^3.10.0",
     "react": "^18.2.0",
     "react-calendar": "^5.1.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^18.2.0",
     "react-map-gl": "^8.0.1",
     "react-router-dom": "^7.2.0",

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect } from 'react';
 import DeckGL from '@deck.gl/react';
 import { Map } from 'react-map-gl/mapbox';
 
@@ -100,6 +100,7 @@ const MapView: React.FC<MapViewProps> = ({ onLoadingStatesChange }) => {
       getTooltip={({ object }) =>
         getMapTooltip({ object, featurePassesFilters })
       }
+      useDevicePixels={false}
       widgets={[
         new ZoomWidget({
           placement: 'top-left',

--- a/src/components/layers/GeoJsonLayer.tsx
+++ b/src/components/layers/GeoJsonLayer.tsx
@@ -1,5 +1,6 @@
 import { GeoJsonLayer } from '@deck.gl/layers';
 import { PathStyleExtension } from '@deck.gl/extensions';
+import { isMobile } from 'react-device-detect';
 
 /**
  * Creates a GeoJson layer for fire perimeters visualization
@@ -91,6 +92,8 @@ export const createGeoJsonLayer2D = ({
     },
 
     getDashArray: (feature) => {
+      if (isMobile) return [0, 0];
+
       const state = getPerimeterState(feature);
 
       switch (state) {
@@ -106,13 +109,9 @@ export const createGeoJsonLayer2D = ({
     },
 
     lineWidthMinPixels: 1,
-    material: {
-      ambient: 0.8,
-      diffuse: 0.6,
-      shininess: 10,
-    },
+    material: isMobile ? false : { ambient: 0.8, diffuse: 0.6, shininess: 10 },
     opacity: opacity / 100,
-    pickable: true,
+    pickable: !isMobile,
 
     updateTriggers: {
       getFillColor: [
@@ -134,7 +133,7 @@ export const createGeoJsonLayer2D = ({
         ...(updateTriggers.getDashArray || []),
       ],
     },
-    extensions: [new PathStyleExtension({ dash: true })],
+    extensions: isMobile ? [] : [new PathStyleExtension({ dash: true })],
     parameters: {
       depthTest: false,
     },

--- a/src/components/layers/WindLayer.tsx
+++ b/src/components/layers/WindLayer.tsx
@@ -1,5 +1,6 @@
 import * as WeatherLayers from 'weatherlayers-gl';
 import { ClipExtension } from '@deck.gl/extensions';
+import { isMobile } from 'react-device-detect';
 
 /**
  * Creates a wind particle layer
@@ -56,12 +57,12 @@ export const createWindLayer = async ({
       bounds: [-134.1214, 21.1222, -60.8912, 52.6287],
       clipBounds: [-134.1214, 21.1222, -60.8912, 52.6287],
       extensions: [new ClipExtension()],
-      numParticles: particleCount,
+      numParticles: isMobile ? 500 : particleCount,
       color: [97, 173, 234, 255],
       fadeOpacity: opacity / 100,
       dropRate: 0.003,
       dropRateBump: 0.01,
-      speedFactor,
+      speedFactor: isMobile ? 5 : speedFactor,
       lineWidth: {
         type: 'exponential',
         value: 2.0,
@@ -69,13 +70,13 @@ export const createWindLayer = async ({
         min: 1.0,
         max: 4.5,
       },
-      maxAge: 15,
-      paths: 25,
+      maxAge: isMobile ? 8 : 15,
+      paths: isMobile ? 10 : 25,
       iconAtlas: '',
       iconMapping: {},
       fadeIn: true,
       useWorkers: true,
-      updateRate: 16,
+      updateRate: isMobile ? 32 : 16,
       blendMode: 'screen',
       particleGradient: {
         0.0: [50, 50, 50, 0],

--- a/src/components/mobile-details/index.tsx
+++ b/src/components/mobile-details/index.tsx
@@ -363,18 +363,16 @@ const MobileDetails: React.FC<MobileDetails> = ({ onBack }) => {
         </div>
       </div>
 
-      <div className="detailed-time-chart bg-white radius-md padding-3 shadow-2 z-top width-full≈">
+      <div className="detailed-time-chart bg-white radius-md padding-2 shadow-2 z-top width-full≈">
         {drawerOpen && (
           <div>
-            <div className="margin-bottom-2">
-              <DetailsToggle
-                setMobileTimelineActive={setMobileTimelineActive}
-                mobileTimelineActive={mobileTimelineActive}
-              />
-            </div>
+            <DetailsToggle
+              setMobileTimelineActive={setMobileTimelineActive}
+              mobileTimelineActive={mobileTimelineActive}
+            />
             {mobileTimelineActive ? (
               <>
-                <div className=" details-container padding-y-2 grid-container  padding-x-0 margin-bottom-2">
+                <div className=" details-container padding-y-2 grid-container  padding-x-0">
                   <div className="grid-row">
                     <div className="grid-col-6 padding-right-1">
                       <label className="usa-checkbox margin-0 border-base-light border-1px radius-md padding-2 display-flex width-full maxh-8 display-flex flex-justify">


### PR DESCRIPTION
Trying out a few mobile optimizations for Deck.gl for the GeoJSON and Wind layers:

1. Disable dashes, picking, and material shading on mobile
2. Cap line widths
3. Reduce particle count, path length, lifetime and update rate of the Wind layer
4. Disable useDevicePixels on mobile/desktop (TBD reverse for desktops in a follow-up)
5. Minor spacing/padding tweak in the mobile details panel
6. Add react-device-detect dependency (to make use of the `isMobile` util)