### PR TITLE
Add SiteAlert Banner for gov shutdown

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   ModalRef,
   ModalToggleButton,
   Tag,
+  SiteAlert
 } from '@trussworks/react-uswds';
 
 import './header.scss';
@@ -46,7 +47,9 @@ const Header: React.FC = () => {
   });
 
   return (
-    <header className="header bg-white height-5 padding-y-05 padding-x-105 display-flex flex-row  tablet:flex-justify-between flex-align-center width-full position-fixed top-0 left-0 z-top">
+    <>
+      <SiteAlert variant="emergency">Due to the lapse in federal government funding, NASA is not updating this website. We sincerely regret this inconvenience.</SiteAlert>
+    <header className="header bg-white height-5 padding-y-05 padding-x-105 display-flex flex-row  tablet:flex-justify-between flex-align-center width-full top-0 left-0 z-top">
       <div className="display-flex flex-align-center width-full tablet:flex-justify-start flex-justify">
         <a
           href="https://earthdata.nasa.gov/dashboard"
@@ -267,6 +270,7 @@ const Header: React.FC = () => {
         </div>
       </Modal>
     </header>
+    </>
   );
 };
 


### PR DESCRIPTION
@aboydnw @brianmfreitag I removed the `position-fixed` from the header so when scrolling down, the header no longer sticks - I thought that was okay, can you confirm?
<img width="1139" height="553" alt="Screenshot 2025-10-01 at 10 29 52 AM" src="https://github.com/user-attachments/assets/e5009e87-45cd-450f-9614-15f8987ad728" />
