### PR TITLE
fix: validate opacity values from react slider

### DIFF
--- a/src/components/sidebar/EventDetailsView.tsx
+++ b/src/components/sidebar/EventDetailsView.tsx
@@ -35,10 +35,12 @@ const EventDetails: React.FC<EventDetailsProps> = ({ onBack, isMobile }) => {
   const [showDownloadMenu, setShowDownloadMenu] = useState(false);
   const downloadRef = useRef<HTMLDivElement>(null);
 
-  const setMapState = useFireExplorerStore((state) => state.setMapState);
+  const setLayerOpacity = useFireExplorerStore.use.setLayerOpacity();
 
-  const setLayerOpacity = (opacity: number) => {
-    setMapState({ layerOpacity: opacity });
+  const handleOpacityChange = (value: number | number[]) => {
+    // ReactSlider can pass arrays for multi-thumb sliders, handle both cases
+    const opacityValue = Array.isArray(value) ? value[0] : value;
+    setLayerOpacity(opacityValue);
   };
 
   useEffect(() => {
@@ -321,7 +323,7 @@ const EventDetails: React.FC<EventDetailsProps> = ({ onBack, isMobile }) => {
                     min={0}
                     max={100}
                     value={layerOpacity}
-                    onChange={setLayerOpacity}
+                    onChange={handleOpacityChange}
                   />
                   <span className="slider-value margin-left-2 text-base-dark border-1px border-base-lighter padding-x-2 padding-y-1">
                     {layerOpacity}%

--- a/src/state/slices/mapSlice.ts
+++ b/src/state/slices/mapSlice.ts
@@ -37,7 +37,14 @@ export const createMapSlice: StateCreator<MapSlice> = (set) => ({
     }),
   setViewStateForUrl: (viewState) => set({ viewStateForUrl: viewState }),
   setMapBounds: (bounds) => set({ mapBounds: bounds }),
-  setLayerOpacity: (opacity) => set({ layerOpacity: opacity }),
+  setLayerOpacity: (opacity) => {
+    if (typeof opacity !== 'number' || isNaN(opacity)) {
+      return;
+    }
+
+    const clampedOpacity = Math.max(0, Math.min(100, opacity));
+    set({ layerOpacity: clampedOpacity });
+  },
   updateViewStateForUrl: (updates) =>
     set((state) => ({
       viewStateForUrl: { ...state.viewStateForUrl, ...updates },


### PR DESCRIPTION
Fixes https://github.com/NASA-IMPACT/us-fire-events-tool/issues/16.

Adds validation on opacity values from React Slider.

To test, run the app locally and visit the app with the same querystring from the upstream ticket, change opacity:

- [link example](http://localhost:5173/dashboard/tools/fire-event-explorer?fireEventExplorer=%7B%22selectedEventId%22%3A73555%2C%22windLayerType%22%3A%22grid%22%2C%22show3DMap%22%3Atrue%2C%22showPerimeterNrt%22%3Atrue%2C%22showFireline%22%3Afalse%2C%22showNewFirepix%22%3Afalse%2C%22viewMode%22%3A%22detail%22%2C%22timeRange%22%3A%7B%22start%22%3A%222025-08-26T03%3A59%3A59.999Z%22%2C%22end%22%3A%222025-09-25T03%3A59%3A59.999Z%22%7D%2C%22selectedDuration%22%3A%7B%22label%22%3A%221+month%22%2C%22value%22%3A2592000000%7D%2C%22viewStateForUrl%22%3A%7B%22width%22%3A1512%2C%22height%22%3A857%2C%22latitude%22%3A43.422010281132614%2C%22longitude%22%3A-122.29972996629053%2C%22zoom%22%3A10.630552073187701%2C%22bearing%22%3A0%2C%22pitch%22%3A42.3%2C%22altitude%22%3A1.5%2C%22maxZoom%22%3A20%2C%22minZoom%22%3A0%2C%22maxPitch%22%3A60%2C%22minPitch%22%3A0%2C%22normalize%22%3Atrue%2C%22position%22%3A%5B0%2C0%2C0%5D%7D%2C%22viewState%22%3A%7B%22longitude%22%3A-122.29972996629053%2C%22latitude%22%3A43.422010281132614%2C%22zoom%22%3A10.630552073187701%2C%22pitch%22%3A42.3%2C%22bearing%22%3A0%7D%7D)

This is ready for review.