### PR TITLE
docs: Add FEDS product disclaimer to initial popup

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -156,9 +156,24 @@ const Header: React.FC = () => {
               create video outputs in GIF or WebM formats.
             </p>
 
-            <p className="wildfire-explorer__modal-description font-sans-sm line-height-body-5 text-ink margin-bottom-1">
+            <p className="wildfire-explorer__modal-description font-sans-sm line-height-body-5 text-ink">
               These fire tracking data are from the Fire Event Data Suite (FEDS)
-              algorithm. Find out more:
+              algorithm.
+            </p>
+
+            <p className="wildfire-explorer__modal-description font-sans-sm line-height-body-5 text-ink">
+              DISCLAIMER: The FEDS data product 
+              is intended to provide situational awareness for ongoing fire 
+              events in the US and Canada, not as a precise estimate of the fire 
+              perimeter for emergency response. This research product estimates 
+              individual fire event perimeters and properties every 12 hours; 
+              the spatial and temporal resolution of each modeled fire perimeter 
+              reflects the characteristics and availability of VIIRS 375 m active 
+              fire detections from FIRMS.
+            </p>
+
+            <p className="wildfire-explorer__modal-description font-sans-sm line-height-body-5 text-ink margin-bottom-1">
+              Find out more:
             </p>
 
             <ul className="wildfire-explorer__modal-list usa-list font-sans-sm margin-top-0 margin-bottom-4">


### PR DESCRIPTION
Hi team! Was requested from higher up to make sure that our disclaimer language is clearly presented to first time users. Feel free to tweak the formatting or use as-is. 

Here is a screenshot of the change in the web UI (added the section "DISCLAIMER"): 

<img width="910" height="636" alt="Screenshot 2026-06-26 at 12 59 16 PM" src="https://github.com/user-attachments/assets/460be088-1e51-47e5-8456-b2c2e80969a7" />


