### PR TITLE
fix: remove /vsicurl prefix from HRRR URIs, encode to be safe

### DIFF
--- a/src/components/layers/GridLayer.tsx
+++ b/src/components/layers/GridLayer.tsx
@@ -34,7 +34,8 @@ export const createGridLayer = async ({ timeMarker, opacity = 92 }) => {
       .toString()
       .padStart(2, '0');
 
-    const imageUrl = `https://openveda.cloud/api/raster/cog/preview.png?rescale=-127,128&url=vrt:///vsicurl/https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${runDateStr}/conus/hrrr.t${runHourStr}z.wrfsfcf${forecastHour}.grib2?bands=10,11&format=png`;
+    const vrtUrl = `vrt://https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${runDateStr}/conus/hrrr.t${runHourStr}z.wrfsfcf${forecastHour}.grib2?bands=10,11`;
+    const imageUrl = `https://openveda.cloud/api/raster/cog/preview.png?rescale=-127,128&url=${encodeURIComponent(vrtUrl)}&format=png`;
 
     let image;
 

--- a/src/components/layers/WindLayer.tsx
+++ b/src/components/layers/WindLayer.tsx
@@ -40,7 +40,8 @@ export const createWindLayer = async ({
       .padStart(2, '0');
 
     const titilerEndpoint = import.meta.env.VITE_TITILER_ENDPOINT || 'https://titiler.xyz';
-    const imageUrl = `${titilerEndpoint}/cog/preview.png?rescale=-127,128&url=vrt:///vsicurl/https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${runDateStr}/conus/hrrr.t${runHourStr}z.wrfsfcf${forecastHour}.grib2?bands=10,11&format=png`;
+    const vrtUrl = `vrt://https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.${runDateStr}/conus/hrrr.t${runHourStr}z.wrfsfcf${forecastHour}.grib2?bands=10,11`;
+    const imageUrl = `${titilerEndpoint}/cog/preview.png?rescale=-127,128&url=${encodeURIComponent(vrtUrl)}&format=png`;
 
     let image;
 


### PR DESCRIPTION
Wind animations are back! I'm not sure why there was a regression here, but removing the `/vsicurl` segment of the dataset URI seemed to fix it (and I url encoded it to be safe). 

<img width="1070" height="774" alt="image" src="https://github.com/user-attachments/assets/fbd41d32-a13a-4b91-8d10-6c566db56e1f" />


resolves #48